### PR TITLE
NT. Add ability to set specific colour for bullet.

### DIFF
--- a/pptx/oxml/__init__.py
+++ b/pptx/oxml/__init__.py
@@ -234,6 +234,7 @@ from .dml.color import (  # noqa: E402
 
 register_element_cls("a:bgClr", CT_Color)
 register_element_cls("a:fgClr", CT_Color)
+register_element_cls("a:buClr", CT_Color)
 register_element_cls("a:hslClr", CT_HslColor)
 register_element_cls("a:lumMod", CT_Percentage)
 register_element_cls("a:lumOff", CT_Percentage)

--- a/pptx/oxml/dml/color.py
+++ b/pptx/oxml/dml/color.py
@@ -52,7 +52,7 @@ class _BaseColorElement(BaseOxmlElement):
 
 
 class CT_Color(BaseOxmlElement):
-    """Custom element class for `a:fgClr`, `a:bgClr` and perhaps others."""
+    """Custom element class for `a:fgClr`, `a:bgClr`, `a:buClr` and perhaps others."""
 
     eg_colorChoice = ZeroOrOneChoice(
         (

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -462,6 +462,7 @@ class CT_TextParagraphProperties(BaseOxmlElement):
     spcBef = ZeroOrOne("a:spcBef", successors=_tag_seq[2:])
     spcAft = ZeroOrOne("a:spcAft", successors=_tag_seq[3:])
     buClrTx = ZeroOrOne("a:buClrTx", successors=_tag_seq[4:])
+    buClr = ZeroOrOne("a:buClr", successors=_tag_seq[5:])
     buNone = ZeroOrOne("a:buNone", successors=_tag_seq[11:])
     buAutoNum = ZeroOrOne("a:buAutoNum", successors=_tag_seq[12:])
     buChar = ZeroOrOne("a:buChar", successors=_tag_seq[13:])


### PR DESCRIPTION
This PR add the ability to set a bullet colour property on a paragraph. 🤞 
This way, a bullet can have its own colour and does not need to rely the first run colour (using `a:buClrTx`).

This is what we have using `a:buClrTx` :
![image](https://user-images.githubusercontent.com/24357048/58560162-73806400-821c-11e9-92b8-4f4565a4030c.png)

